### PR TITLE
Adição de um novo campo chamado numero de dígitos do convênio

### DIFF
--- a/src/main/java/org/jrimum/domkee/financeiro/banco/febraban/ContaBancaria.java
+++ b/src/main/java/org/jrimum/domkee/financeiro/banco/febraban/ContaBancaria.java
@@ -88,7 +88,12 @@ public class ContaBancaria {
 	 * @see Modalidade
 	 */
 	private Modalidade modalidade;
-	
+		
+	/**
+	 * Numero de Digitos do Convênio. Utilizado para geração do campo livre 
+	 * do Banco do Brasil, ele pode assumir dois valores 6 ou 7
+	 */
+	private Integer numeroDigConvenio;
 	
 	public ContaBancaria() {}
 	
@@ -197,4 +202,18 @@ public class ContaBancaria {
 	public String toString() {
 		return Objects.toString(this);
 	}
+
+	public Integer getNumeroDigConvenio() {
+		return numeroDigConvenio;
+	}
+
+	/**
+	 * Numero de Digitos do Convênio. Utilizado para geração do campo livre 
+	 * do Banco do Brasil, ele pode assumir dois valores 6 ou 7
+	 */
+	public void setNumeroDigConvenio(Integer numeroDigConvenio) {
+		this.numeroDigConvenio = numeroDigConvenio;
+	}
+
+	
 }


### PR DESCRIPTION
Adição de um novo campo chamado numero de dígitos do convênio, que será usado no bopepo para geração do campo livre do Banco do Brasil, como uma alternativa à lógica que levava em conta o número da conta (<100000), ele pode assumir dois valores 6 ou 7. Peguei um caso aonde o número da conta era menor, porém o convênio tinha 7 dígitos, o que acabou gerando um boleto inválido
